### PR TITLE
Set noUpdateTTL/updateAgeOnGet from constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ class TTLCache {
     }
     this.ttl = ttl
     this.max = max
+    this.updateAgeOnGet = updateAgeOnGet;
+    this.noUpdateTTL = noUpdateTTL;
     if (dispose !== undefined) {
       if (typeof dispose !== 'function') {
         throw new TypeError('dispose must be function if set')

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,30 @@ t.test('basic operation', async t => {
   t.equal(c.get(1), undefined)
 })
 
+t.test('constructor - updateAgeOnGet', async t => {
+  const c = new TTL({ttl: 1000, updateAgeOnGet: true})
+  c.set(1, 2)
+
+  t.equal(c.getRemainingTTL(1), 1000)
+  clock.advance(5)
+  t.equal(c.getRemainingTTL(1), 995)
+
+  c.get(1) // Should reset timer
+  t.equal(c.getRemainingTTL(1), 1000)
+})
+
+t.test('constructor - noUpdateTTL', async t => {
+  const c = new TTL({ttl: 1000, noUpdateTTL: true})
+  c.set(1, 2)
+
+  t.equal(c.getRemainingTTL(1), 1000)
+  clock.advance(5)
+  t.equal(c.getRemainingTTL(1), 995)
+
+  c.set(1, 3) // Should not update timer
+  t.equal(c.getRemainingTTL(1), 995)
+})
+
 t.test('bad values', async t => {
   t.throws(() => new TTL({max: -1}))
   t.throws(() => new TTL({ttl: -1}))


### PR DESCRIPTION
This commit updates the TTLCache constructor to use the previously
unused constructor arguments noUpdateTTL and updateAgeOnGet as defaults.