### PR TITLE
fix: reset the timeout for purgeStale when exp > n

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,9 @@ class TTLCache {
     const n = now()
     for (const exp in this.expirations) {
       if (exp > n) {
+        const t = setTimeout(() => this.purgeStale(), Math.ceil(exp - n))
+        /* istanbul ignore else - affordance for non-node envs */
+        if (t.unref) t.unref()
         return
       }
       for (const key of this.expirations[exp]) {


### PR DESCRIPTION
purgeStale when the condition `exp > n` is met, the code will return without resetting the timeout, which disallows the cache to be purged again later.

This issue causes a random cache stale issue. This issue can be covered for the active update cache use case as a later `set` action will reset the timeout. But for cache not every active, the cache can be stale for a long time.