### PR TITLE
add missing index.d.ts for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@isaacs/ttlcache",
   "version": "1.0.4",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
Currently, `index.d.ts` is not being included in the npm package, breaking any imports of it into TypeScript. Adding this line to the package.json should resolve this.