### PR TITLE
Reduce memory usage by only creating one timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ automatically.
 Called when an item is removed from the cache and should be disposed.  Set
 this on the constructor options.
 
+### `setTimer`
+
+**Internal**
+
+Called when an with a ttl is added. This ensures that only one timer
+is setup at once. Called automatically.
+
 ## Algorithm
 
 The cache uses two `Map` objects.  The first maps item keys to their

--- a/test/graceful-clear.ts
+++ b/test/graceful-clear.ts
@@ -13,13 +13,13 @@ const cache = new TTLCache({
   ttl: 10,
 })
 
-const timers: Set<NodeJS.Timeout> = (cache as unknown as { timers: Set<NodeJS.Timeout> }).timers
+const cacheWithTimer = (cache as unknown as { timer: NodeJS.Timeout | undefined })
 cache.set('a', 'b', { ttl: 1e9 })
-t.equal(timers.size, 1)
+t.type(cacheWithTimer.timer, 'object')
 cache.clear()
-t.equal(timers.size, 0)
+t.equal(cacheWithTimer.timer, undefined)
 
 cache.set('a', 'b', { ttl: 1e9 })
-t.equal(timers.size, 1)
+t.type(cacheWithTimer.timer, 'object')
 cache.delete('a')
-t.equal(timers.size, 0)
+t.equal(cacheWithTimer.timer, undefined)


### PR DESCRIPTION
This reduces memory usage and also speeds up the `.set` calls by a factor of 2.6.