### PR TITLE
Fix import syntax typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Custom size calculation is not supported. Max capacity is simply the count
 of items in the cache.
 
 ```js
-import { TTLCache } from '@isaacs/ttlcache')
+import { TTLCache } from '@isaacs/ttlcache'
 const cache = new TTLCache({ max: 10000, ttl: 1000 })
 
 // set some value


### PR DESCRIPTION
What the title says